### PR TITLE
Fix Non Invertible Matrix Issue - Compute Flattening

### DIFF
--- a/computeFlattening.m
+++ b/computeFlattening.m
@@ -11,7 +11,15 @@ n_eq = size(A,1);
 M=[L A'; A sparse(n_eq,n_eq)];
 rhs=[zeros(n_vars,1); b];
 warning('off','MATLAB:nearlySingularMatrix')
-x_lambda = M \ rhs;
+
+% Use Tekhonov Regularization for calculating x_lambda
+% Reference: Tikhonov, A. N., & Arsenin, V. Y. (1977). Solutions of Ill-Posed Problems. Winston & Sons.
+% addresses rank deficiency in the original M matrix
+% specify alpha: 
+% - small enough to meet error requirements
+% - large enough to make eignvalues not zero 
+alpha = 1e-10;
+x_lambda = (M' * M + alpha * speye(size(M,2))) \ (M' * rhs);
 warning('on','MATLAB:nearlySingularMatrix')
 e=max(abs(M*x_lambda-rhs));
 fprintf('error: %e\n',e);

--- a/computeFlattening.m
+++ b/computeFlattening.m
@@ -12,7 +12,7 @@ M=[L A'; A sparse(n_eq,n_eq)];
 rhs=[zeros(n_vars,1); b];
 warning('off','MATLAB:nearlySingularMatrix')
 
-% Use Tekhonov Regularization for calculating x_lambda
+% Use Tikhonov Regularization for calculating x_lambda
 % Reference: Tikhonov, A. N., & Arsenin, V. Y. (1977). Solutions of Ill-Posed Problems. Winston & Sons.
 % addresses rank deficiency in the original M matrix
 % specify alpha: 


### PR DESCRIPTION

**Description of the Issue:** 
Upon running the script_orbifold_sphere command, the following error occured (details below). The root cause was identified in the computeFlattening.m script, where the inverse of matrix _M_ is multiplied by matrix _rhs_.  Matrix  _M_ is not invertible, leading to the propagation of a NaN matrix _x_lambda_ until the script fails at an assertion.

**Matrix M:** 
size: 5328 x 5328
rank: 5320 (deficient) 
determinant: NaN

**Proposed Solution:**
By using Tikhonov Regularization, the 0 values within Matrix _M_ are shifted by a small constant  (_alpha : 1e-10_) . This in turn fixes the rank deficiency problem and successfully runs the following 3 scripts

**Verified Scripts:** 
_1. script_orbifold_sphere
2. script_orbifold_disk
3. script_NOT_ORBIFOLD_spherical_tutte_

Remaining Observations: 
The calculated determinant of _M_ still appears to be unstable even after regularization (Inf). However, the linear constraint checks defined in the script have passed.


Original Error Message: 
<img width="771" alt="Error_Message" src="https://github.com/user-attachments/assets/c562a740-5b45-47c1-a045-2e6efd5af151">
